### PR TITLE
[Feat] #11 XIB 셀 등록 및 화면 데이터 연결과 디자인 입히기(스크롤, autoDimension 포함)

### DIFF
--- a/TravelTalkChatting/Base.lproj/Main.storyboard
+++ b/TravelTalkChatting/Base.lproj/Main.storyboard
@@ -88,6 +88,9 @@
                                         <rect key="frame" x="36" y="23" width="283" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
+                                        <connections>
+                                            <action selector="didEndOnExitTextfield:" destination="1T8-jd-nQL" eventType="editingDidEndOnExit" id="YCj-EH-9R7"/>
+                                        </connections>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Kl-hR-GBQ">
                                         <rect key="frame" x="327" y="25" width="30" height="30"/>

--- a/TravelTalkChatting/Extension/String+Extension.swift
+++ b/TravelTalkChatting/Extension/String+Extension.swift
@@ -21,4 +21,14 @@ extension String {
         return newString
     }
 
+    func stringToDateToString2() -> String {
+        String.dateformatter.locale = Locale(identifier: "ko_KR")
+        String.dateformatter.dateFormat = "yyyy-MM-dd HH:mm"
+        guard let newDate = String.dateformatter.date(from: self) else { return "" }
+        
+        String.dateformatter.dateFormat = "a HH:mm"
+        let newString = String.dateformatter.string(from: newDate)
+        
+        return newString
+    }
 }

--- a/TravelTalkChatting/Extension/UITextView+Extension.swift
+++ b/TravelTalkChatting/Extension/UITextView+Extension.swift
@@ -1,0 +1,17 @@
+//
+//  UITextView+Extension.swift
+//  TravelTalkChatting
+//
+//  Created by Lee Wonsun on 1/12/25.
+//
+
+import UIKit
+
+extension UITextView {
+    
+    func commonDesign(color: UIColor = .label, size: CGFloat = 16, weight: UIFont.Weight = .bold, line: Int = 1) {
+        self.textColor = color
+        self.font = .systemFont(ofSize: size, weight: weight)
+        self.textAlignment = .left
+    }
+}

--- a/TravelTalkChatting/TableViewCell/FriendChatTableViewCell.swift
+++ b/TravelTalkChatting/TableViewCell/FriendChatTableViewCell.swift
@@ -11,7 +11,7 @@ class FriendChatTableViewCell: UITableViewCell {
     
     static let identifier = "FriendChatTableViewCell"
     
-    @IBOutlet var profileImageVew: UIImageView!
+    @IBOutlet var profileImageView: UIImageView!
     @IBOutlet var friendNameLabel: UILabel!
     @IBOutlet var friendchatTextView: UITextView!
     @IBOutlet var messageDateLabel: UILabel!
@@ -22,10 +22,37 @@ class FriendChatTableViewCell: UITableViewCell {
         // Initialization code
     }
 
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
+    func configFriendChat(_ chatlist: Chat, _ tableView: UITableView) {
+        
+        self.selectionStyle = .none
+        self.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: tableView.bounds.width)
+        
+        profileImageView.image = UIImage(named: chatlist.user.rawValue)
+        profileImageView.contentMode = .scaleAspectFill
+        DispatchQueue.main.async {
+            self.profileImageView.layer.cornerRadius = self.profileImageView.frame.width / 2
+        }
+        profileImageView.clipsToBounds = true
+        
+        friendNameLabel.text = chatlist.user.rawValue
+        friendNameLabel.commonDesign(size: 15, weight: .medium)
+        
+        messageDateLabel.text = chatlist.date.stringToDateToString2()
+        messageDateLabel.commonDesign(color: .systemGray, size: 12, weight: .semibold)
+        messageDateLabel.textAlignment = .right
+        
+        friendchatTextView.text = chatlist.message
+        
+        friendchatTextView.textColor = .darkText
+        friendchatTextView.textAlignment = .left
+        friendchatTextView.font = .systemFont(ofSize: 15, weight: .medium)
+        friendchatTextView.isScrollEnabled = false
+        friendchatTextView.isEditable = false
+        friendchatTextView.textContainerInset = UIEdgeInsets(top: 12, left: 4, bottom: 12, right: 4)
+        friendchatTextView.layer.borderWidth = 1.5
+        friendchatTextView.layer.borderColor = UIColor.systemGray3.cgColor
+        friendchatTextView.layer.cornerRadius = 15
+        friendchatTextView.backgroundColor = .white
     }
     
 }

--- a/TravelTalkChatting/TableViewCell/FriendChatTableViewCell.xib
+++ b/TravelTalkChatting/TableViewCell/FriendChatTableViewCell.xib
@@ -31,7 +31,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="kUc-pS-FjA">
-                        <rect key="frame" x="73" y="43.333333333333336" width="206" height="78.666666666666657"/>
+                        <rect key="frame" x="73" y="39.333333333333336" width="206" height="82.666666666666657"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                         <color key="textColor" systemColor="labelColor"/>
@@ -50,7 +50,7 @@
                     </label>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="kUc-pS-FjA" firstAttribute="top" secondItem="jSa-6Z-bPh" secondAttribute="bottom" constant="12" id="0p5-h7-KNZ"/>
+                    <constraint firstItem="kUc-pS-FjA" firstAttribute="top" secondItem="jSa-6Z-bPh" secondAttribute="bottom" constant="8" id="0p5-h7-KNZ"/>
                     <constraint firstItem="kUc-pS-FjA" firstAttribute="leading" secondItem="jSa-6Z-bPh" secondAttribute="leading" id="1Uw-K6-NmT"/>
                     <constraint firstItem="j07-Zv-apm" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="CoV-sC-ZnV"/>
                     <constraint firstAttribute="bottom" secondItem="WBl-Qp-yVH" secondAttribute="bottom" constant="12" id="GES-FC-GbG"/>
@@ -67,7 +67,7 @@
                 <outlet property="friendNameLabel" destination="jSa-6Z-bPh" id="Hu4-7M-uN1"/>
                 <outlet property="friendchatTextView" destination="kUc-pS-FjA" id="YGF-RB-bvS"/>
                 <outlet property="messageDateLabel" destination="WBl-Qp-yVH" id="xzC-LH-Eq3"/>
-                <outlet property="profileImageVew" destination="j07-Zv-apm" id="8aw-oX-Sx3"/>
+                <outlet property="profileImageView" destination="j07-Zv-apm" id="8aw-oX-Sx3"/>
             </connections>
             <point key="canvasLocation" x="-228.24427480916029" y="-7.042253521126761"/>
         </tableViewCell>

--- a/TravelTalkChatting/TableViewCell/MyChatTableViewCell.swift
+++ b/TravelTalkChatting/TableViewCell/MyChatTableViewCell.swift
@@ -19,7 +19,11 @@ class MyChatTableViewCell: UITableViewCell {
         
     }
     
-    func configMyChat(_ chatlist: Chat) {
+    func configMyChat(_ chatlist: Chat, _ tableView: UITableView) {
+        
+        self.selectionStyle = .none
+        self.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: tableView.bounds.width)
+        
         messageDateLabel.text = chatlist.date.stringToDateToString2()
         messageDateLabel.commonDesign(color: .systemGray, size: 12, weight: .semibold)
         messageDateLabel.textAlignment = .right

--- a/TravelTalkChatting/TableViewCell/MyChatTableViewCell.swift
+++ b/TravelTalkChatting/TableViewCell/MyChatTableViewCell.swift
@@ -18,6 +18,25 @@ class MyChatTableViewCell: UITableViewCell {
         super.awakeFromNib()
         
     }
+    
+    func configMyChat(_ chatlist: Chat) {
+        messageDateLabel.text = chatlist.date.stringToDateToString2()
+        messageDateLabel.commonDesign(color: .systemGray, size: 12, weight: .semibold)
+        messageDateLabel.textAlignment = .right
+        
+        mychatTextView.text = chatlist.message
+        
+        mychatTextView.textColor = .darkText
+        mychatTextView.textAlignment = .left
+        mychatTextView.font = .systemFont(ofSize: 15, weight: .medium)
+        mychatTextView.isScrollEnabled = false
+        mychatTextView.isEditable = false
+        mychatTextView.textContainerInset = UIEdgeInsets(top: 12, left: 4, bottom: 12, right: 4)
+        mychatTextView.layer.borderWidth = 1.5
+        mychatTextView.layer.borderColor = UIColor.systemGray3.cgColor
+        mychatTextView.layer.cornerRadius = 15
+        mychatTextView.backgroundColor = .systemGray6
+    }
 
     
 }

--- a/TravelTalkChatting/TableViewCell/MyChatTableViewCell.swift
+++ b/TravelTalkChatting/TableViewCell/MyChatTableViewCell.swift
@@ -16,13 +16,8 @@ class MyChatTableViewCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+        
     }
 
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
     
 }

--- a/TravelTalkChatting/TableViewCell/MyChatTableViewCell.xib
+++ b/TravelTalkChatting/TableViewCell/MyChatTableViewCell.xib
@@ -28,10 +28,10 @@
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                     </textView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="88:88 오후" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rVZ-gN-t3Z">
-                        <rect key="frame" x="45" y="88" width="60" height="20"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="88:88:88 오후" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rVZ-gN-t3Z">
+                        <rect key="frame" x="15" y="88" width="90" height="20"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="60" id="ij2-0d-7nX"/>
+                            <constraint firstAttribute="width" constant="90" id="ij2-0d-7nX"/>
                             <constraint firstAttribute="height" constant="20" id="o9L-ti-BeO"/>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="12"/>

--- a/TravelTalkChatting/ViewController/ChattingViewController.swift
+++ b/TravelTalkChatting/ViewController/ChattingViewController.swift
@@ -25,6 +25,8 @@ class ChattingViewController: UIViewController {
         print(listIndex)
         print(mockChatList[listIndex].chatList.count)
         
+        navigationItem.title = mockChatList[listIndex].chatroomName
+        
         registerCells()
         configUI()
     }

--- a/TravelTalkChatting/ViewController/ChattingViewController.swift
+++ b/TravelTalkChatting/ViewController/ChattingViewController.swift
@@ -57,16 +57,21 @@ extension ChattingViewController: UITableViewDelegate, UITableViewDataSource {
             
             guard let cell = tableView.dequeueReusableCell(withIdentifier: MyChatTableViewCell.identifier, for: indexPath) as? MyChatTableViewCell else { return UITableViewCell() }
             
-            cell.messageDateLabel.text = chatlist.date.stringToDateToString2()
-            cell.messageDateLabel.commonDesign(color: .systemGray, size: 12, weight: .semibold)
-            cell.messageDateLabel.textAlignment = .right
-            cell.mychatTextView.text = chatlist.message
+            cell.selectionStyle = .none
+            cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: tableView.bounds.width)
             
+            cell.configMyChat(chatlist)
             
             return cell
         } else {
             
             guard let cell = tableView.dequeueReusableCell(withIdentifier: FriendChatTableViewCell.identifier, for: indexPath) as? FriendChatTableViewCell else { return UITableViewCell() }
+            
+            cell.selectionStyle = .none
+            cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: tableView.bounds.width)
+            
+            cell.friendchatTextView.isScrollEnabled = false
+            cell.friendchatTextView.isEditable = false
             
             return cell
         }

--- a/TravelTalkChatting/ViewController/ChattingViewController.swift
+++ b/TravelTalkChatting/ViewController/ChattingViewController.swift
@@ -57,8 +57,11 @@ extension ChattingViewController: UITableViewDelegate, UITableViewDataSource {
             
             guard let cell = tableView.dequeueReusableCell(withIdentifier: MyChatTableViewCell.identifier, for: indexPath) as? MyChatTableViewCell else { return UITableViewCell() }
             
-            cell.messageDateLabel.text = chatlist.date.stringToDateToString()
+            cell.messageDateLabel.text = chatlist.date.stringToDateToString2()
+            cell.messageDateLabel.commonDesign(color: .systemGray, size: 12, weight: .semibold)
+            cell.messageDateLabel.textAlignment = .right
             cell.mychatTextView.text = chatlist.message
+            
             
             return cell
         } else {

--- a/TravelTalkChatting/ViewController/ChattingViewController.swift
+++ b/TravelTalkChatting/ViewController/ChattingViewController.swift
@@ -27,9 +27,26 @@ class ChattingViewController: UIViewController {
         
         navigationItem.title = mockChatList[listIndex].chatroomName
         
+        
+        // 🥲🙋🏻‍♀️ 스크롤은 하는데, 뭔가 화면이 전환되는게 보이고 나서 내려가니 부자연 스러운데 방법이 없을지, 지연시키지 않으면 호출 순서로 인해 오류가 발생함
+        DispatchQueue.main.async { [self] in
+            let indexPath = IndexPath(item: mockChatList[self.listIndex].chatList.count - 1, section: 0)
+            chatTableView.scrollToRow(at: indexPath, at: UITableView.ScrollPosition.bottom, animated: true)
+        }
+        
         registerCells()
         configUI()
+        chatTableView.rowHeight = UITableView.automaticDimension
     }
+    
+    // 아래 방법은 좀 반응이 느림
+   /* override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        let indexPath = IndexPath(item: mockChatList[self.listIndex].chatList.count - 1, section: 0)
+        chatTableView.scrollToRow(at: indexPath, at: UITableView.ScrollPosition.bottom, animated: true)
+        
+    } */
 
     @IBAction func didEndOnExitTextfield(_ sender: UITextField) {
     }
@@ -99,9 +116,5 @@ extension ChattingViewController: UITableViewDelegate, UITableViewDataSource {
             return cell
         }
 
-    }
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 100
     }
 }

--- a/TravelTalkChatting/ViewController/ChattingViewController.swift
+++ b/TravelTalkChatting/ViewController/ChattingViewController.swift
@@ -57,21 +57,14 @@ extension ChattingViewController: UITableViewDelegate, UITableViewDataSource {
             
             guard let cell = tableView.dequeueReusableCell(withIdentifier: MyChatTableViewCell.identifier, for: indexPath) as? MyChatTableViewCell else { return UITableViewCell() }
             
-            cell.selectionStyle = .none
-            cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: tableView.bounds.width)
-            
-            cell.configMyChat(chatlist)
+            cell.configMyChat(chatlist, tableView)
             
             return cell
         } else {
             
             guard let cell = tableView.dequeueReusableCell(withIdentifier: FriendChatTableViewCell.identifier, for: indexPath) as? FriendChatTableViewCell else { return UITableViewCell() }
-            
-            cell.selectionStyle = .none
-            cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: tableView.bounds.width)
-            
-            cell.friendchatTextView.isScrollEnabled = false
-            cell.friendchatTextView.isEditable = false
+ 
+            cell.configFriendChat(chatlist, tableView)
             
             return cell
         }

--- a/TravelTalkChatting/ViewController/ChattingViewController.swift
+++ b/TravelTalkChatting/ViewController/ChattingViewController.swift
@@ -17,10 +17,60 @@ class ChattingViewController: UIViewController {
     @IBOutlet var sendButton: UIButton!
     @IBOutlet var chatTextField: UITextField!
     
+    var listIndex: Int = 0
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        print(listIndex)
+        print(mockChatList[listIndex].chatList.count)
+        
+        registerCells()
     }
 
+}
+
+// MARK: - TableView 관련 설정
+extension ChattingViewController: UITableViewDelegate, UITableViewDataSource {
+    
+    func registerCells() {
+        
+        chatTableView.delegate = self
+        chatTableView.dataSource = self
+        
+        
+        let xib1 = UINib(nibName: MyChatTableViewCell.identifier, bundle: nil)
+        let xib2 = UINib(nibName: FriendChatTableViewCell.identifier, bundle: nil)
+        chatTableView.register(xib1, forCellReuseIdentifier: MyChatTableViewCell.identifier)
+        chatTableView.register(xib2, forCellReuseIdentifier: FriendChatTableViewCell.identifier)
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return mockChatList[listIndex].chatList.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        let chatlist = mockChatList[listIndex].chatList[indexPath.row]
+        
+        if chatlist.user == .user {
+            
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: MyChatTableViewCell.identifier, for: indexPath) as? MyChatTableViewCell else { return UITableViewCell() }
+            
+            cell.messageDateLabel.text = chatlist.date.stringToDateToString()
+            cell.mychatTextView.text = chatlist.message
+            
+            return cell
+        } else {
+            
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: FriendChatTableViewCell.identifier, for: indexPath) as? FriendChatTableViewCell else { return UITableViewCell() }
+            
+            return cell
+        }
+
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 100
+    }
 }

--- a/TravelTalkChatting/ViewController/ChattingViewController.swift
+++ b/TravelTalkChatting/ViewController/ChattingViewController.swift
@@ -29,6 +29,8 @@ class ChattingViewController: UIViewController {
         configUI()
     }
 
+    @IBAction func didEndOnExitTextfield(_ sender: UITextField) {
+    }
 }
 
 // MARK: - View 관련
@@ -58,6 +60,8 @@ extension ChattingViewController {
 extension ChattingViewController: UITableViewDelegate, UITableViewDataSource {
     
     func registerCells() {
+        
+        chatTableView.keyboardDismissMode = .onDrag
         
         chatTableView.delegate = self
         chatTableView.dataSource = self

--- a/TravelTalkChatting/ViewController/ChattingViewController.swift
+++ b/TravelTalkChatting/ViewController/ChattingViewController.swift
@@ -26,8 +26,32 @@ class ChattingViewController: UIViewController {
         print(mockChatList[listIndex].chatList.count)
         
         registerCells()
+        configUI()
     }
 
+}
+
+// MARK: - View 관련
+extension ChattingViewController {
+    
+    func configUI() {
+        
+        let placeholder = "메세지를 입력하세요 *_*"
+        
+        bgUIView.backgroundColor = .systemBackground
+        
+        chatboxImageView.backgroundColor = .systemGray6
+        chatboxImageView.layer.cornerRadius = 10
+        
+        chatTextField.borderStyle = .none
+        chatTextField.placeholder = placeholder
+        chatTextField.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor : UIColor.gray, NSAttributedString.Key.font : UIFont.systemFont(ofSize: 15, weight: .medium)])
+        chatTextField.keyboardType = .default
+        
+        sendButton.setTitle("", for: .normal)
+        sendButton.setImage(UIImage(systemName: "paperplane")?.withTintColor(.systemGray3, renderingMode: .alwaysOriginal), for: .normal)
+    }
+    
 }
 
 // MARK: - TableView 관련 설정

--- a/TravelTalkChatting/ViewController/TravelTalkViewController.swift
+++ b/TravelTalkChatting/ViewController/TravelTalkViewController.swift
@@ -31,6 +31,9 @@ class TravelTalkViewController: UIViewController {
         registerCells()
         configCollectionViewLayout()
         confingSearchBar()
+        
+        navigationItem.backButtonTitle = ""
+        navigationController?.navigationBar.tintColor = .label
     }
 
 

--- a/TravelTalkChatting/ViewController/TravelTalkViewController.swift
+++ b/TravelTalkChatting/ViewController/TravelTalkViewController.swift
@@ -137,6 +137,8 @@ extension TravelTalkViewController: UICollectionViewDelegate, UICollectionViewDa
         let sb = UIStoryboard(name: "Main", bundle: nil)
         guard let vc = sb.instantiateViewController(withIdentifier: ChattingViewController.identifier) as? ChattingViewController else { return }
         
+        vc.listIndex = indexPath.item
+        
         navigationController?.pushViewController(vc, animated: true)
     }
 }


### PR DESCRIPTION
## 한 일
1. 내 채팅셀과 친구 셀 2개 각각 tableView에 등록
2. 앞에서 네비게이션으로 화면 전환할 때, indexPath.row 데이터 받아서 넘겨서, 해당 인덱스에 있는 데이터로 채팅창 연결
3. 스크롤이 필요한 채팅방은 진입 시 자동으로 맨 아래로 스크롤 내려가도록 구현
`        DispatchQueue.main.async { [self] in
            let indexPath = IndexPath(item: mockChatList[self.listIndex].chatList.count - 1, section: 0)
            chatTableView.scrollToRow(at: indexPath, at: UITableView.ScrollPosition.bottom, animated: true)
        }`
- 지연안걸고 viewDidLoad()에 두면 호출 순서로 이상 생김
4. rowHeight = tableview.autoDimension으로 채팅창 길이에 맞게 변하도록 설정

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-12 at 02 38 03](https://github.com/user-attachments/assets/49a64cd7-f861-4dae-9b38-4a2ef2f4db2c)
