### PR TITLE
[Feat] 채팅 내용 mockChatList에 저장 후 채팅창에 업데이트 시켜주기

### DIFF
--- a/TravelTalkChatting/Base.lproj/Main.storyboard
+++ b/TravelTalkChatting/Base.lproj/Main.storyboard
@@ -100,6 +100,9 @@
                                         </constraints>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                        <connections>
+                                            <action selector="sendButtonTapped:" destination="1T8-jd-nQL" eventType="touchUpInside" id="aE4-wU-00t"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemGray3Color"/>

--- a/TravelTalkChatting/Extension/Date+Extension.swift
+++ b/TravelTalkChatting/Extension/Date+Extension.swift
@@ -1,0 +1,19 @@
+//
+//  Date+Extension.swift
+//  TravelTalkChatting
+//
+//  Created by Lee Wonsun on 1/12/25.
+//
+
+import Foundation
+
+extension Date {
+    
+    func DateToString() -> String {
+        String.dateformatter.dateFormat = "yyyy-MM-dd HH:mm"
+        let newDate = String.dateformatter.string(from: self)
+        
+        return newDate
+    }
+    
+}

--- a/TravelTalkChatting/Model/ChattingData.swift
+++ b/TravelTalkChatting/Model/ChattingData.swift
@@ -37,7 +37,7 @@ struct Chat {
 }
 
 
-let mockChatList: [ChatRoom] = [
+var mockChatList: [ChatRoom] = [
     ChatRoom(chatroomId: 1,
              chatroomImage: [User.hue.profileImage, User.jack.profileImage, User.bran.profileImage, User.den.profileImage],
              chatroomName: "도봉 멘토방",

--- a/TravelTalkChatting/ViewController/ChattingViewController.swift
+++ b/TravelTalkChatting/ViewController/ChattingViewController.swift
@@ -7,6 +7,12 @@
 
 import UIKit
 
+/*
+ < 추가로 시도해본 것 >
+ (옵션들 중 추후 코드베이스 학습 후 터득해서 써볼만한 목록들은 이해하지 않고 쓰기보단 차후로 미뤄둠)
+ - 내가 쓴 텍스트를 send 버튼 누르면 더미데이터에 추가되어 채팅창이 업데이트 될 수 있도록 시도? => 성공
+ */
+
 class ChattingViewController: UIViewController {
     
     static let identifier = "ChattingViewController"
@@ -37,6 +43,7 @@ class ChattingViewController: UIViewController {
         registerCells()
         configUI()
         chatTableView.rowHeight = UITableView.automaticDimension
+        
     }
     
     // 아래 방법은 좀 반응이 느림
@@ -48,6 +55,21 @@ class ChattingViewController: UIViewController {
         
     } */
 
+    @IBAction func sendButtonTapped(_ sender: UIButton) {
+        
+        guard let newText = chatTextField.text else { return }
+        mockChatList[listIndex].chatList.append(Chat(user: .user, date: Date().DateToString(), message: newText))
+        
+        chatTableView.reloadData()
+        
+        
+        // reload하고 스크롤 안내려주면 저장된 내용이 안보임
+        let indexPath = IndexPath(item: mockChatList[self.listIndex].chatList.count - 1, section: 0)
+        chatTableView.scrollToRow(at: indexPath, at: UITableView.ScrollPosition.bottom, animated: true)
+        
+        chatTextField.text = ""   
+    }
+    
     @IBAction func didEndOnExitTextfield(_ sender: UITextField) {
     }
 }


### PR DESCRIPTION
## 한 일
1. 채팅 내용 보내기 버튼 누르면 화면에 업데이트 시키기
- 버튼 누르는 순간 mockChatList에 append 시키기
- 데이터 리로드 한 후 스크롤 다시 아래로 내려가도록 시키기
- 전송 후 textfield는 비워지도록 초기화

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-12 at 20 45 34](https://github.com/user-attachments/assets/dd7eff2e-8ffa-471c-a154-00afc9f7b7c1)
